### PR TITLE
Hotfix estilos CSS - Encapsula reglas en componentes proyectores.

### DIFF
--- a/src/components/projectors/FormBox.vue
+++ b/src/components/projectors/FormBox.vue
@@ -138,4 +138,5 @@ const props = defineProps({
 
     </div> <!-- /root container. -->
 </template>
-
+<style scoped>
+</style>

--- a/src/views/projectors/ControlPanel.vue
+++ b/src/views/projectors/ControlPanel.vue
@@ -1066,7 +1066,7 @@ const deleteSelectedCommandsRequest = async () => {
     </div>
 </template>
 
-<style>
+<style scoped>
 .modal {
     z-index: 1050 !important;
     /* Default value for Bootstrap modal */

--- a/src/views/projectors/EventsTable.vue
+++ b/src/views/projectors/EventsTable.vue
@@ -439,7 +439,7 @@ const gradientStyle = computed(() => ({
 
 </template>
 
-<style>
+<style scoped>
 body {
     margin: 0;
     padding: 0;

--- a/src/views/projectors/RemoteControl.vue
+++ b/src/views/projectors/RemoteControl.vue
@@ -905,3 +905,7 @@ const alertClass = computed(() => {
 		</div>
 	</div>
 </template>
+
+
+<style scoped>
+</style>


### PR DESCRIPTION
Encapsula los estilos de las vistas del apartado de proyectores en ambito limitado para no afectar de manera global a componentes ajenos a estas vistas.

Modifica:
- src/components/projectors/FormBox.vue
- src/views/projectors/ControlPanel.vue
- src/views/projectors/EventsTable.vue
- src/views/projectors/RemoteControl.vue